### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "objtree",
+  "version": "1.0.0",
+  "description": "Generate a nicely formatted representation of an object tree",
+  "main": "objtree.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chylex/objtree.git"
+  },
+  "keywords": [
+    "object",
+    "tree",
+    "view",
+    "generator",
+    "browser"
+  ],
+  "author": "Daniel Chýlek <contact@chylex.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/chylex/objtree/issues"
+  },
+  "homepage": "https://github.com/chylex/objtree#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "objtree",
+  "name": "@deckhack/objtree",
   "version": "1.0.0",
   "description": "Generate a nicely formatted representation of an object tree",
   "main": "objtree.js",


### PR DESCRIPTION
Just adds a `package.json` so the package can be published to npm.

I just see another problem, which is the conflicting package name. There already is a package named [objtree](https://www.npmjs.com/package/objtree) existing on npm.

This could be solved if you publish the package under the [DeckHack](https://www.npmjs.com/org/deckhack) npm organization. It would be named as `@deckhack/objtree` then tho.

_Or you find another name!_